### PR TITLE
Add multi-lang and VS Code support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Run tests",
+            "script": "${workspaceFolder}/RunTests.ps1",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/translations.json
+++ b/translations.json
@@ -1,0 +1,24 @@
+{
+  "captiontranslations": [
+    {
+      "culture": "en-US",
+      "captions": {
+        "run": "Selektierte ausführen",
+        "result": "Ergebnis",
+        "success": "Erfolg",
+        "codeunit": "Codeunit",
+        "function": "Funktion"
+      }
+    },
+    {
+      "culture": "de-DE",
+      "captions": {
+        "run": "Selektierte ausführen",
+        "result": "Ergebnis",
+        "success": "Erfolg",
+        "codeunit": "Codeunit",
+        "function": "Funktion"
+      }
+    }
+  ]
+}

--- a/translations.json
+++ b/translations.json
@@ -3,11 +3,11 @@
     {
       "culture": "en-US",
       "captions": {
-        "run": "Selektierte ausführen",
-        "result": "Ergebnis",
-        "success": "Erfolg",
+        "run": "Run",
+        "result": "Result",
+        "success": "Success",
         "codeunit": "Codeunit",
-        "function": "Funktion"
+        "function": "Function"
       }
     },
     {


### PR DESCRIPTION
- Add multi-lang support through a .json file containing the translations
- Add a VS Code launch config to be able to directly launch the test tool in VS Code