### PR TITLE
fix(XUnit): Make test name unique (Issue #5)

### DIFF
--- a/PsTestRunner.ps1
+++ b/PsTestRunner.ps1
@@ -118,7 +118,7 @@ function Run-Tests
                     $XUnitCollection.SetAttribute("total",([int]$XUnitCollection.GetAttribute("total")+1))
                     $XUnitTest = $XUnitDoc.CreateElement("test")
                     $XUnitCollection.AppendChild($XUnitTest) | Out-Null
-                    $XUnitTest.SetAttribute("name", $XUnitAssembly.GetAttribute("name"))
+                    $XUnitTest.SetAttribute("name", $XUnitAssembly.GetAttribute("name")+':'+$Name)
                     $XUnitTest.SetAttribute("method", $Name)
                     $XUnitTest.SetAttribute("time", ([Math]::Round($duration.TotalSeconds,3)).ToString([System.Globalization.CultureInfo]::InvariantCulture))
                 }


### PR DESCRIPTION
Test name must be unique, else wrong names are displayed in Azure DevOps.